### PR TITLE
docs: fix typo in command name

### DIFF
--- a/doc/updatemarks.tex
+++ b/doc/updatemarks.tex
@@ -211,12 +211,12 @@ they are the automatical updating list.
 
 \begin{function}[added=2024-02-19]{\ExtractMarksTo}
   \begin{syntax}
-    \verb|\ExtractMarks| \marg{box number} \marg{cmd}
-    \verb|\ExtractMarks| \oarg{number list} \marg{box number} \marg{cmd}
-    \verb|\ExtractMarks| * \marg{text} \marg{cmd}
-    \verb|\ExtractMarks| * \oarg{number list} \marg{text} \marg{cmd}
+    \verb|\ExtractMarksTo| \marg{box number} \marg{cmd}
+    \verb|\ExtractMarksTo| \oarg{number list} \marg{box number} \marg{cmd}
+    \verb|\ExtractMarksTo| * \marg{text} \marg{cmd}
+    \verb|\ExtractMarksTo| * \oarg{number list} \marg{text} \marg{cmd}
   \end{syntax}
-It collect all marks to \meta{cmd}, you can use \meta{cmd} to reinsert these marks.
+It collects all marks to \meta{cmd}, then you can use \meta{cmd} to reinsert these marks.
 
 \texttt{insertmark} hook would not be used as it's already been used.
 \end{function}


### PR DESCRIPTION
BTW it seems version 0.2f 2024-10-07 was uploaded to CTAN (see [announcement](https://ctan.org/ctan-ann/id/ZwT3CCRXOOjF0jxq@prptp)) but not pushed to GitHub yet?